### PR TITLE
Adding CMake infrastructure and build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: build
+
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup
+      run: |
+        sudo apt update -y
+        sudo apt install -y cmake libopenmpi-dev openmpi-bin
+
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        cmake .. 
+        make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,5 +18,5 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake .. 
+        cmake ..
         make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.20)
+
+set(CMAKE_Fortran_COMPILER gfortran)
+project(REcoM LANGUAGES Fortran)
+find_package(MPI REQUIRED)
+
+# Get the list of Fortran sources in the folder
+file(GLOB_RECURSE SOURCES "*.?90")
+
+# Sets the fortran flag to allow files with no line length limit
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-none")
+
+# This is currently required because recom_sinking currently relies on this definition
+add_compile_definitions(__recom)
+
+# Create the target library for REcoM and add its dependencies
+add_library(recom ${SOURCES})
+target_link_libraries(recom PUBLIC MPI::MPI_Fortran)

--- a/recom_init.F90
+++ b/recom_init.F90
@@ -640,7 +640,7 @@ subroutine recom_init(nl, ulevels_nod2D, nlevels_nod2D, geo_coord_nod2D, Z_3d_n,
     tracers_info%data_pointers(21)%tracer_data(:,:) = max(tiny, tracers_info%data_pointers(21)%tracer_data(:,:))
 !------------------------------------------
 
-    if(mype==0) write(*,*),'Tracers have been initialized as spinup from WOA/glodap netcdf files'
+    if(mype==0) write(*,*) 'Tracers have been initialized as spinup from WOA/glodap netcdf files'
         locDINmax = -66666
         locDINmin = 66666
         locDICmax = locDINmax


### PR DESCRIPTION
This PR adds a basic CMakeLists.txt file for building the REcoM library.

It also adds a new workflow for building the library in a CI job for testing purposes.

This partly addresses #2.