### PR TITLE
FESOM CI build fix with REcoM as submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,4 +14,9 @@ add_compile_definitions(__recom)
 
 # Create the target library for REcoM and add its dependencies
 add_library(recom STATIC ${SOURCES})
+
+if(DEFINED ENV{GITHUB_ACTIONS})
+    target_compile_options(recom PRIVATE -O2 -g -fbacktrace -ffloat-store -finit-local-zero  -finline-functions -fimplicit-none  -fdefault-real-8 -fdefault-double-8 -ffree-line-length-none -cpp)
+endif()
+
 target_link_libraries(recom PUBLIC MPI::MPI_Fortran)


### PR DESCRIPTION
When FESOM runs its own CI, it has checks in the CMakeLists which apply specific compilations flags for this scenario. When REcoM source files were directly used, the compilations flags would be applied to them directly. Now since REcoM is built as a library, these flags have also to be added to the REcoM build side, otherwise simulation results will vary slightly.