### PR TITLE
Changes to support Albedo builds

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,4 +24,5 @@ repos:
     hooks:
       - id: fortitude
         exclude: 'mocsy'
-        args: [--target-std, "f2008", --line-length, "101"]
+        # Rule C121 refers to the use of the 'only' clause in imports
+        args: [--target-std, "f2008", --line-length, "101", --ignore, C121]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,39 +6,36 @@ find_package(MPI REQUIRED)
 # Get the list of Fortran sources in the folder
 file(GLOB_RECURSE SOURCES "*.?90")
 
-if(${CMAKE_Fortran_COMPILER_ID} STREQUAL  GNU )
-    # Sets the fortran flag to allow files with no line length limit
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-none")
-endif()
-
-# This is currently required because recom_sinking currently relies on this definition
+# This is currently required because recom_sinking relies on this definition
 add_compile_definitions(__recom)
 
 # Create the target library for REcoM and add its dependencies
 add_library(recom STATIC ${SOURCES})
 
+# CMAKE_Fortran_COMPILER_ID will also work if a wrapper is being used (e.g. mpif90 wraps ifort -> compiler id is Intel)
+if(${CMAKE_Fortran_COMPILER_ID} STREQUAL  Intel OR ${CMAKE_Fortran_COMPILER_ID} STREQUAL  IntelLLVM )
+
+    # Base compiler flags
+    target_compile_options(${PROJECT_NAME} PRIVATE -O3 -r8 -i4 -fp-model precise -no-prec-div -fimf-use-svml -init=zero -no-wrap-margin -fpe0 -fpp)
+    target_compile_options(${PROJECT_NAME} PRIVATE -march=core-avx2 -fPIC -qopt-malloc-options=2 -qopt-prefetch=5 -unroll-aggressive)
+
+    # compiler flags not supported by IntelLLVM
+    if(${CMAKE_Fortran_COMPILER_ID} STREQUAL  Intel )
+        target_compile_options(${PROJECT_NAME} PRIVATE -no-prec-sqrt -ip )
+    endif()
+
+elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL  GNU )
+
+    # Sets the fortran flag to allow files with no line length limit
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-none")
+    target_compile_options(recom PRIVATE -ffree-line-length-none)
+
+endif()
+
 if(DEFINED ENV{GITHUB_ACTIONS})
 
-    # CMAKE_Fortran_COMPILER_ID will also work if a wrapper is being used (e.g. mpif90 wraps ifort -> compiler id is Intel)
-    if(${CMAKE_Fortran_COMPILER_ID} STREQUAL  Intel OR ${CMAKE_Fortran_COMPILER_ID} STREQUAL  IntelLLVM )
-
-        # Base compiler flags
-        target_compile_options(${PROJECT_NAME} PRIVATE -O3 -r8 -i4 -fp-model precise -no-prec-div -fimf-use-svml -init=zero -no-wrap-margin -fpe0 -fpp)
-   
-        # compiler flags not supported by IntelLLVM
-        if(${CMAKE_Fortran_COMPILER_ID} STREQUAL  Intel )
-            target_compile_options(${PROJECT_NAME} PRIVATE -no-prec-sqrt -ip )
-        endif()
-
-        #if    (${RECOM_PLATFORM_STRATEGY} STREQUAL levante.dkrz.de )
-            # Nothing here
-        #elseif(${RECOM_PLATFORM_STRATEGY} STREQUAL albedo)
-            # PROCESSORS: 2x AMD Rome Epyc 7702 (64 cores each), 128 cores, 256 GB RAM
-        target_compile_options(${PROJECT_NAME} PRIVATE -march=core-avx2 -fPIC -qopt-malloc-options=2 -qopt-prefetch=5 -unroll-aggressive) # -g -traceback -check) #NEC mpi option
-        #endif()
-
-    elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL  GNU )
-        target_compile_options(recom PRIVATE -O2 -g -fbacktrace -ffloat-store -finit-local-zero  -finline-functions -fimplicit-none  -fdefault-real-8 -fdefault-double-8 -ffree-line-length-none -cpp)
+    if(${CMAKE_Fortran_COMPILER_ID} STREQUAL  GNU )
+        target_compile_options(recom PRIVATE -O2 -g -fbacktrace -ffloat-store -finit-local-zero  -finline-functions -fimplicit-none -fdefault-real-8 -fdefault-double-8 -cpp)
     endif()
 
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,10 @@ find_package(MPI REQUIRED)
 # Get the list of Fortran sources in the folder
 file(GLOB_RECURSE SOURCES "*.?90")
 
-# Sets the fortran flag to allow files with no line length limit
-set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-none")
+if(${CMAKE_Fortran_COMPILER_ID} STREQUAL  GNU )
+    # Sets the fortran flag to allow files with no line length limit
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-none")
+endif()
 
 # This is currently required because recom_sinking currently relies on this definition
 add_compile_definitions(__recom)
@@ -16,7 +18,29 @@ add_compile_definitions(__recom)
 add_library(recom STATIC ${SOURCES})
 
 if(DEFINED ENV{GITHUB_ACTIONS})
-    target_compile_options(recom PRIVATE -O2 -g -fbacktrace -ffloat-store -finit-local-zero  -finline-functions -fimplicit-none  -fdefault-real-8 -fdefault-double-8 -ffree-line-length-none -cpp)
+
+    # CMAKE_Fortran_COMPILER_ID will also work if a wrapper is being used (e.g. mpif90 wraps ifort -> compiler id is Intel)
+    if(${CMAKE_Fortran_COMPILER_ID} STREQUAL  Intel OR ${CMAKE_Fortran_COMPILER_ID} STREQUAL  IntelLLVM )
+
+        # Base compiler flags
+        target_compile_options(${PROJECT_NAME} PRIVATE -O3 -r8 -i4 -fp-model precise -no-prec-div -fimf-use-svml -init=zero -no-wrap-margin -fpe0 -fpp)
+   
+        # compiler flags not supported by IntelLLVM
+        if(${CMAKE_Fortran_COMPILER_ID} STREQUAL  Intel )
+            target_compile_options(${PROJECT_NAME} PRIVATE -no-prec-sqrt -ip )
+        endif()
+
+        #if    (${RECOM_PLATFORM_STRATEGY} STREQUAL levante.dkrz.de )
+            # Nothing here
+        #elseif(${RECOM_PLATFORM_STRATEGY} STREQUAL albedo)
+            # PROCESSORS: 2x AMD Rome Epyc 7702 (64 cores each), 128 cores, 256 GB RAM
+        target_compile_options(${PROJECT_NAME} PRIVATE -march=core-avx2 -fPIC -qopt-malloc-options=2 -qopt-prefetch=5 -unroll-aggressive) # -g -traceback -check) #NEC mpi option
+        #endif()
+
+    elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL  GNU )
+        target_compile_options(recom PRIVATE -O2 -g -fbacktrace -ffloat-store -finit-local-zero  -finline-functions -fimplicit-none  -fdefault-real-8 -fdefault-double-8 -ffree-line-length-none -cpp)
+    endif()
+
 endif()
 
 target_link_libraries(recom PUBLIC MPI::MPI_Fortran)

--- a/recom_extra.F90
+++ b/recom_extra.F90
@@ -197,7 +197,7 @@ contains
             areasvol)
 
         use recom_declarations, only: wp
-        use mpi!, only: MPI_DOUBLE_PRECISION, MPI_SUM, MPI_Allreduce
+        use mpi
 
         implicit none
 

--- a/recom_extra.F90
+++ b/recom_extra.F90
@@ -197,7 +197,7 @@ contains
             areasvol)
 
         use recom_declarations, only: wp
-        use mpi, only: MPI_DOUBLE_PRECISION, MPI_SUM, MPI_Allreduce
+        use mpi!, only: MPI_DOUBLE_PRECISION, MPI_SUM, MPI_Allreduce
 
         implicit none
 

--- a/recom_gen_halo_exchange.F90
+++ b/recom_gen_halo_exchange.F90
@@ -175,7 +175,7 @@ contains
     !=======================================
 
     subroutine recom_exchange_nod_end(npes, request_count, array_of_requests)
-        use mpi, only: MPI_WAITALL, MPI_STATUSES_IGNORE
+        use mpi!, only: MPI_WAITALL, MPI_STATUSES_IGNORE
         implicit none
 
         integer, intent(in) :: request_count, npes

--- a/recom_gen_halo_exchange.F90
+++ b/recom_gen_halo_exchange.F90
@@ -175,7 +175,7 @@ contains
     !=======================================
 
     subroutine recom_exchange_nod_end(npes, request_count, array_of_requests)
-        use mpi!, only: MPI_WAITALL, MPI_STATUSES_IGNORE
+        use mpi
         implicit none
 
         integer, intent(in) :: request_count, npes

--- a/recom_init.F90
+++ b/recom_init.F90
@@ -459,7 +459,7 @@ contains
         use recom_config, only: enable_3zoo2det, enable_coccos
         use recom_declarations, only: WP, is_3zoo2det, is_coccos
 
-        use mpi, only: MPI_allreduce, MPI_DOUBLE_PRECISION, MPI_MAX, MPI_MIN
+        use mpi!, only: MPI_allreduce, MPI_DOUBLE_PRECISION, MPI_MAX, MPI_MIN
 
         implicit none
 

--- a/recom_init.F90
+++ b/recom_init.F90
@@ -459,7 +459,7 @@ contains
         use recom_config, only: enable_3zoo2det, enable_coccos
         use recom_declarations, only: WP, is_3zoo2det, is_coccos
 
-        use mpi!, only: MPI_allreduce, MPI_DOUBLE_PRECISION, MPI_MAX, MPI_MIN
+        use mpi
 
         implicit none
 


### PR DESCRIPTION
This PR removes the `only` clauses for MPI imports, since the Albedo stack has problems with it.

It also expands and improves the cmake build.