### PR TITLE
tracer_ids: default conditional ids to -1 sentinel

### DIFF
--- a/recom_modules.F90
+++ b/recom_modules.F90
@@ -377,22 +377,25 @@ module REcoM_declarations
         integer :: detrital_calcite
 
         ! --- 3zoo2det extra tracers ---
-        integer :: macrozooplankton_nitrogen
-        integer :: macrozooplankton_carbon
-        integer :: macrozooplankton_detrital_nitrogen
-        integer :: macrozooplankton_detrital_carbon
-        integer :: macrozooplankton_detrital_silica
-        integer :: macrozooplankton_detrital_calcite
-        integer :: microzooplankton_nitrogen
-        integer :: microzooplankton_carbon
+        ! Default -1 sentinel: these are only assigned in initialize_tracer_ids when the
+        ! corresponding &parecomsetup flag is on. -1 never matches a real tracer id, so
+        ! id-based lookups (e.g. the otracers output loop) correctly skip inactive species.
+        integer :: macrozooplankton_nitrogen = -1
+        integer :: macrozooplankton_carbon = -1
+        integer :: macrozooplankton_detrital_nitrogen = -1
+        integer :: macrozooplankton_detrital_carbon = -1
+        integer :: macrozooplankton_detrital_silica = -1
+        integer :: macrozooplankton_detrital_calcite = -1
+        integer :: microzooplankton_nitrogen = -1
+        integer :: microzooplankton_carbon = -1
 
         ! --- coccos extra tracers ---
-        integer :: coccolithophore_nitrogen
-        integer :: coccolithophore_carbon
-        integer :: coccolithophore_chlorophyll
-        integer :: phaeocystis_nitrogen
-        integer :: phaeocystis_carbon
-        integer :: phaeocystis_chlorophyll
+        integer :: coccolithophore_nitrogen = -1
+        integer :: coccolithophore_carbon = -1
+        integer :: coccolithophore_chlorophyll = -1
+        integer :: phaeocystis_nitrogen = -1
+        integer :: phaeocystis_carbon = -1
+        integer :: phaeocystis_chlorophyll = -1
 
     end type recom_tracer_ids
 


### PR DESCRIPTION
## Summary

Give the conditionally-active components of `recom_tracer_ids` (the 3zoo2det and coccos tracers) an explicit `-1` default in the type definition, so their id is a defined value even when the corresponding `&parecomsetup` switch is off. This keeps id-based lookups against `tracer_ids%*` well-defined for every configuration. It adds no runtime cost and does not change behaviour when a species is active.

## Merge order

FESOM/fesom2#806 ("AWI-ESM3 CO2 coupling") pins the REcoM submodule at this branch's commit, so merging this PR is a prerequisite for #806 to resolve its submodule against upstream REcoM. Please merge as a merge commit or a rebase rather than a squash, so the pinned commit stays reachable from `master`. A squash would create a new SHA, and #806 would then need its submodule pointer updated.

## Background: why this is needed

`initialize_tracer_ids` assigns the macrozoo, microzoo, coccolithophore and phaeocystis ids only inside `if (enable_3zoo2det)` / `if (enable_coccos)`:

```fortran
if (enable_coccos) then
    tracer_ids%coccolithophore_nitrogen = current_tracer_id
    ...
end if
```

When a species is switched off, its component is never assigned.

The motivating consumer lives on the FESOM side (FESOM/fesom2#806): the `io_meandata` `otracers` output loop is being changed from hardcoded absolute ids to the symbolic `tracer_ids%*`. The absolute-id version is wrong for any `coccos=off` configuration, because ids are assigned positionally. With coccos off, the ids the old code hardcoded as `CoccoN`/`CoccoC` (1029/1030) actually belong to microzooplankton, so those tracers were written to file under the wrong name. Switching to `tracer_ids%*` fixes that across every `&parecomsetup` combination, but only if the symbolic component holds a sane value when its species is off, because the comparison

```fortran
else if (tracers%data(j)%ID == tracer_ids%coccolithophore_nitrogen) then
```

is evaluated for every tracer in every configuration. This PR provides that sane value.

## Why -1 cannot collide

`-1` is also used as the tracer-list terminator, so it is fair to ask whether it can clash. It cannot. `oce_setup_step.F90` truncates the tracer count at the first `-1` entry:

```fortran
do n=1, num_tracers
   if (nml_tracer_list(n)%id == -1) then
      num_tracers = n-1        ! stop before the terminator
      EXIT
   end if
end do
tracers%num_tracers = num_tracers
tracers%data(n)%ID  = nml_tracer_list(n)%id   ! only n = 1..num_tracers
```

Every `tracers%data(j)%ID` that the output loop can see is a real tracer id (temperature, salinity, sea ice, or the biogeochemistry ids from 1001 upward). A `-1` is never stored as an active tracer id, so a `tracer_ids%*` left at `-1` compares as `ID == -1`, which is always `.false.` for real tracers. This holds on every compiler.

## Why default it at all rather than leave it unset

Leaving the component unset happens to work on a normal optimised build, because module data lands in zero-filled BSS and `0` is not an id the loop compares against (the loop starts past temperature and salinity, and every id it sees is 1001 or higher). Relying on that means relying on undefined behaviour, which I would rather avoid:

- It is not guaranteed by the standard. Debug and checking builds deliberately poison uninitialised integers (for example `gfortran -finit-integer=...`, or NAG's undefined-variable checks), which would make the value non-zero and the read a flagged error.
- The REcoM CI hooks (Codee and Fortitude) exist precisely to catch reads of unset variables, so this would likely surface as a finding.

An explicit `-1` costs nothing and documents intent. It turns "almost certainly fine but undefined" into "provably fine and portable".

To be clear about magnitude: this is not a claim that the running model silently mislabels tracers today. On a normal build it does not. The change is about correctness by construction and passing static analysis, not about fixing an observed production failure.

## Alternatives considered

- Guarding each comparison with `enable_*` (`enable_coccos .and. ID == tracer_ids%...`). Rejected, because Fortran does not mandate short-circuit `.and.`, so the undefined component may still be read. It trades the collision question for an undefined-read question and is more invasive at the call site.
- Assigning the sentinel inside `initialize_tracer_ids` instead of on the type. Same effect, but it moves the "always defined" guarantee away from the declaration and still assigns `-1` unconditionally. Keeping the default on the type keeps the invariant next to the data.

If you would rather not reuse the same magic number as the list terminator, I am happy to switch `-1` to a more distinctive value such as `-999`. There is no functional difference given the truncation guarantee above.

## Scope

This touches only the type definition in one file. Active species are unaffected, because the `enable_*` blocks overwrite the default with the real id, and there is no runtime cost.