### PR TITLE
feat(recom): fix BGC-only loop bounds to exclude transient tracers

### DIFF
--- a/recom_init.F90
+++ b/recom_init.F90
@@ -36,9 +36,17 @@ contains
     !   - 3 Zooplankton: Het, Zoo2, Zoo3
     !   - 2 Detritus pools
     !===============================================================================
+    !
+    ! Tracer layout (fixed order):
+    !   T, S  |  BGC (bgc_num tracers)  |  age (optional, ID=100)  |  transit (optional)
+    !
+    ! BGC tracers always start immediately at slot 3, regardless of whether
+    ! transit tracers are active. Transit tracers (SF6, CFC-11, CFC-12, R14C,
+    ! R39Ar) are appended at the very end, after the optional age tracer.
+    !===============================================================================
     subroutine recom_init(nl, ulevels_nod2D, nlevels_nod2D, geo_coord_nod2D, Z_3d_n, myDim_nod2d, &
             eDim_nod2D, mype, MPI_COMM_FESOM, myDim_elem2D, eDim_elem2D, tracers_info, &
-            num_tracers, rad, use_age_tracer)
+            num_tracers, rad, use_age_tracer, use_transit, l_sf6, l_f11, l_f12, l_r14c, l_r39ar)
 
         use REcoM_declarations, only: wp, tracer_ids
         use REcoM_GloVar, only: tracers_info_type
@@ -50,12 +58,16 @@ contains
         integer, intent(in) :: nl, mydim_nod2d, edim_nod2d, mype, num_tracers
         integer, intent(in) :: mpi_comm_fesom, mydim_elem2d, edim_elem2d
         real(kind=WP), intent(in) :: rad
-        logical, intent(in) :: use_age_tracer
+        logical, intent(in) :: use_age_tracer, use_transit, l_sf6, l_f11, l_f12, l_r14c, l_r39ar
         integer, intent(in), dimension(:) :: ulevels_nod2d, nlevels_nod2d
         real(kind=wp), intent(in), dimension(:, :) :: geo_coord_nod2d, z_3d_n
         type(tracers_info_type), intent(in) :: tracers_info
 
         integer :: i, tracer_id
+        integer :: actual_bgc_num
+        integer :: num_physical_tracers
+        integer :: n_transit_tracers   ! number of active transit tracers
+        integer :: bgc_start, bgc_end  ! first/last slot of the BGC-only block
 
         call initialize_memory(myDim_nod2D + eDim_nod2D, nl, num_tracers)
 
@@ -65,13 +77,35 @@ contains
         call initialize_tracer_indices
 
         ! Validation check here
-        call validate_recom_tracers(num_tracers, use_age_tracer, mype)
+        call validate_recom_tracers(num_tracers, use_age_tracer, use_transit, l_sf6, l_f11, l_f12, l_r14c, l_r39ar, mype)
 
         ! After reading tracer namelist - validate actual IDs
-        call validate_tracer_id_sequence(tracers_info%ids(1:num_tracers), num_tracers, use_age_tracer, mype)
+        call validate_tracer_id_sequence(tracers_info%ids(1:num_tracers), num_tracers, use_age_tracer, use_transit, &
+                                            l_sf6, l_f11, l_f12, l_r14c, l_r39ar, mype)
 
-        ! Initializes tracer data
-        do i = num_tracers - bgc_num + 1, num_tracers
+        ! T,S | BGC | [age] | [transit] num_physical_tracers
+        ! is always just T,S (=2): BGC tracers start right after them, regardless
+        ! of whether transit tracers are active. Transit tracers are appended at
+        ! the tail instead and are not initialized here.
+        num_physical_tracers = 2
+
+        n_transit_tracers = 0
+        if (use_transit) then
+            if (l_sf6)   n_transit_tracers = n_transit_tracers + 1
+            if (l_f11)   n_transit_tracers = n_transit_tracers + 1
+            if (l_f12)   n_transit_tracers = n_transit_tracers + 1
+            if (l_r14c)  n_transit_tracers = n_transit_tracers + 1
+            if (l_r39ar) n_transit_tracers = n_transit_tracers + 1
+        end if
+
+        actual_bgc_num = num_tracers - num_physical_tracers
+        if (use_age_tracer) actual_bgc_num = actual_bgc_num - 1
+        if (use_transit) actual_bgc_num = actual_bgc_num - n_transit_tracers
+
+        bgc_start = num_physical_tracers + 1
+        bgc_end   = num_physical_tracers + actual_bgc_num
+
+        do i = bgc_start, bgc_end
             tracer_id = tracers_info%ids(i)
 
             !Iron (unit conversion: mol/L => umol/m3)
@@ -80,7 +114,7 @@ contains
                 tracers_info%data_pointers(i)%tracer_data(:, :) = &
                         tracers_info%data_pointers(i)%tracer_data(:, :) * 1.e9
 
-                ! Avoids tracers 1001, 1002, 1003, 1018 and 1022
+                ! Avoids tracers 1001, 1002, 1003, 1018 and 1022, age tracer 100
             else if (tracer_id > 1003 .and. tracer_id /= 1018 .and. tracer_id /= 1022) then
                 tracers_info%data_pointers(i)%tracer_data(:, :) = get_tracer_init_value(tracer_id)
             end if
@@ -439,6 +473,12 @@ contains
 
         integer :: row, k, nzmin, nzmax
 
+        ! Iron tracer (ID=1019) is always BGC tracer #17 in the base block
+        ! (1004..1022 shifted by 1003), so with the fixed T,S | BGC | [age] |
+        ! [transit] layout it always sits at slot 21 (= 2 physical + 19th BGC
+        ! slot: 1019 - 1000 = 19 -> n_base_physical + 19 = 2 + 19 = 21).
+        integer, parameter :: iron_slot = 21
+
         ! Mask hydrothermal vent in Eastern Equatorial Pacific GO
         do row = 1, myDim_nod2D + eDim_nod2D
             !if (ulevels_nod2D(row)>1) cycle
@@ -451,15 +491,15 @@ contains
                         .and. ((geo_coord_nod2D(1, row) > -106.0 * rad) .and. (geo_coord_nod2D(1, &
                         row) < -72.0 * rad))) then
                     if (abs(Z_3d_n(k, row)) < 2000.0_WP) cycle
-                    tracers_info%data_pointers(21)%tracer_data(k, row) = min(0.3, tracers_info%&
-                            data_pointers(21)%tracer_data(k, row)) ! OG todo: try 0.6
+                    tracers_info%data_pointers(iron_slot)%tracer_data(k, row) = &
+                            min(0.3, tracers_info%data_pointers(iron_slot)%tracer_data(k, row)) ! OG todo: try 0.6
                 end if
             end do
         end do
 
         ! Mask negative values
-        tracers_info%data_pointers(21)%tracer_data(:, :) = &
-                max(tiny, tracers_info%data_pointers(21)%tracer_data(:, :))
+        tracers_info%data_pointers(iron_slot)%tracer_data(:, :) = &
+                max(tiny, tracers_info%data_pointers(iron_slot)%tracer_data(:, :))
     end subroutine mask_hydrothermal_vents
 
     subroutine initialization_diagnostics(tracers_info, myDim_nod2D, ulevels_nod2D, nlevels_nod2D, &
@@ -482,6 +522,21 @@ contains
         real(kind=WP) :: locAlkmin, locDSimax, locDSimin, locDFemax, locDFemin
         real(kind=WP) :: locO2max, locO2min
 
+        ! With the fixed T,S | BGC | [age] | [transit] layout, BGC tracers
+        ! always start at slot 3 (right after T,S) regardless of use_transit.
+        ! These fixed slot numbers are therefore now constant and correct:
+        !   DIN (1001) -> slot 3, DIC (1002) -> slot 4, Alk (1003) -> slot 5,
+        !   DSi (1018) -> slot 20, DFe (1019) -> slot 21, O2 (1022) -> slot 24
+        ! (previously these shifted whenever use_transit was active, which was
+        ! a bug: this fixed indexing is now always correct, independent of
+        ! use_transit.)
+        integer, parameter :: din_slot = 3
+        integer, parameter :: dic_slot = 4
+        integer, parameter :: alk_slot = 5
+        integer, parameter :: dsi_slot = 20
+        integer, parameter :: dfe_slot = 21
+        integer, parameter :: o2_slot  = 24
+
         if (mype == 0) write(*, *) 'Tracers have been initialized as spinup from WOA/glodap' // &
                 ' netcdf files'
         locDINmax = -66666
@@ -498,29 +553,29 @@ contains
         locO2min = locDINmin
 
         do n = 1, myDim_nod2d
-            locDINmax = max(locDINmax, maxval(tracers_info%data_pointers(3)%tracer_data(&
+            locDINmax = max(locDINmax, maxval(tracers_info%data_pointers(din_slot)%tracer_data(&
                     ulevels_nod2D(n):nlevels_nod2D(n) - 1, n)))
-            locDINmin = min(locDINmin, minval(tracers_info%data_pointers(3)%tracer_data(&
+            locDINmin = min(locDINmin, minval(tracers_info%data_pointers(din_slot)%tracer_data(&
                     ulevels_nod2D(n):nlevels_nod2D(n) - 1, n)))
-            locDICmax = max(locDICmax, maxval(tracers_info%data_pointers(4)%tracer_data(&
+            locDICmax = max(locDICmax, maxval(tracers_info%data_pointers(dic_slot)%tracer_data(&
                     ulevels_nod2D(n):nlevels_nod2D(n) - 1, n)))
-            locDICmin = min(locDICmin, minval(tracers_info%data_pointers(4)%tracer_data(&
+            locDICmin = min(locDICmin, minval(tracers_info%data_pointers(dic_slot)%tracer_data(&
                     ulevels_nod2D(n):nlevels_nod2D(n) - 1, n)))
-            locAlkmax = max(locAlkmax, maxval(tracers_info%data_pointers(5)%tracer_data(&
+            locAlkmax = max(locAlkmax, maxval(tracers_info%data_pointers(alk_slot)%tracer_data(&
                     ulevels_nod2D(n):nlevels_nod2D(n) - 1, n)))
-            locAlkmin = min(locAlkmin, minval(tracers_info%data_pointers(5)%tracer_data(&
+            locAlkmin = min(locAlkmin, minval(tracers_info%data_pointers(alk_slot)%tracer_data(&
                     ulevels_nod2D(n):nlevels_nod2D(n) - 1, n)))
-            locDSimax = max(locDSimax, maxval(tracers_info%data_pointers(20)%tracer_data(&
+            locDSimax = max(locDSimax, maxval(tracers_info%data_pointers(dsi_slot)%tracer_data(&
                     ulevels_nod2D(n):nlevels_nod2D(n) - 1, n)))
-            locDSimin = min(locDSimin, minval(tracers_info%data_pointers(20)%tracer_data(&
+            locDSimin = min(locDSimin, minval(tracers_info%data_pointers(dsi_slot)%tracer_data(&
                     ulevels_nod2D(n):nlevels_nod2D(n) - 1, n)))
-            locDFemax = max(locDFemax, maxval(tracers_info%data_pointers(21)%tracer_data(&
+            locDFemax = max(locDFemax, maxval(tracers_info%data_pointers(dfe_slot)%tracer_data(&
                     ulevels_nod2D(n):nlevels_nod2D(n) - 1, n)))
-            locDFemin = min(locDFemin, minval(tracers_info%data_pointers(21)%tracer_data(&
+            locDFemin = min(locDFemin, minval(tracers_info%data_pointers(dfe_slot)%tracer_data(&
                     ulevels_nod2D(n):nlevels_nod2D(n) - 1, n)))
-            locO2max = max(locO2max, maxval(tracers_info%data_pointers(24)%tracer_data(&
+            locO2max = max(locO2max, maxval(tracers_info%data_pointers(o2_slot)%tracer_data(&
                     ulevels_nod2D(n):nlevels_nod2D(n) - 1, n)))
-            locO2min = min(locO2min, minval(tracers_info%data_pointers(24)%tracer_data(&
+            locO2min = min(locO2min, minval(tracers_info%data_pointers(o2_slot)%tracer_data(&
                     ulevels_nod2D(n):nlevels_nod2D(n) - 1, n)))
         end do
 

--- a/recom_main.F90
+++ b/recom_main.F90
@@ -86,6 +86,14 @@ end module bio_fluxes_interface
 ! Purpose: Top-level REcoM biogeochemistry driver. Loops over all local nodes,
 !          sets up per-column forcing, calls REcoM_Forcing, collects diagnostics,
 !          and performs MPI halo exchanges.
+!
+! Tracer layout (fixed order): T, S | BGC (bgc_num tracers) | age (optional) |
+! transit (optional: SF6, CFC-11, CFC-12, R14C, R39Ar). BGC tracers always
+! start right after T, S (slot 3) and always occupy exactly bgc_num
+! contiguous slots; age (if enabled) and transit tracers (if enabled) are
+! appended after the BGC block, in that order, and must be excluded from any
+! loop that is meant to touch BGC tracers only.
+
 ! ==============================================================================
 module recom_interface
     implicit none
@@ -100,7 +108,8 @@ contains
             eDim_nod2D, mype, MPI_COMM_FESOM, tracers_info, num_tracers, tra_recom_sms, &
             npes, sn, rn, s_mpitype_nod2D, r_mpitype_nod2D, s_mpitype_nod3D, r_mpitype_nod3D, &
             sPE, rPE, requests, nreq, dt, daynew, month, mstep, ndpyr, yearold, timenew, rad, &
-            kappa, press_air, u_wind, v_wind, shortwave, use_age_tracer)
+            kappa, press_air, u_wind, v_wind, shortwave, use_age_tracer, use_transit, &
+            l_sf6, l_f11, l_f12, l_r14c, l_r39ar)
 
         use recom_g_comm_auto, only: recom_exchange_nod
 
@@ -153,7 +162,7 @@ contains
         real(kind=WP), intent(in), dimension(:, :) :: hnode, z_3d_n, zbar_3d_n
         real(kind=WP), intent(in), dimension(:, :) :: geo_coord_nod2D, areasvol
         real(kind=WP), intent(inout), dimension(:, :, :) :: tra_recom_sms
-        logical, intent(in) :: use_age_tracer
+        logical, intent(in) :: use_age_tracer, use_transit, l_sf6, l_f11, l_f12, l_r14c, l_r39ar
 
         ! These should all go into a dedicated REcoM type
         integer, intent(in) :: sn, rn, npes
@@ -205,6 +214,9 @@ contains
 
         integer                    :: actual_bgc_num
         integer                    :: num_physical_tracers
+        integer                    :: n_transit_tracers   ! number of active transit tracers
+        integer                    :: bgc_start, bgc_end  ! first/last slot of the BGC-only block
+ 
 
         allocate(Temp(nl - 1), Sali_depth(nl - 1), zr(nl - 1), PAR(nl - 1))
         allocate(C(nl - 1, bgc_num))
@@ -249,8 +261,22 @@ contains
         end if
 
         num_physical_tracers = 2
+
+        n_transit_tracers = 0
+        if (use_transit) then
+            if (l_sf6)   n_transit_tracers = n_transit_tracers + 1
+            if (l_f11)   n_transit_tracers = n_transit_tracers + 1
+            if (l_f12)   n_transit_tracers = n_transit_tracers + 1
+            if (l_r14c)  n_transit_tracers = n_transit_tracers + 1
+            if (l_r39ar) n_transit_tracers = n_transit_tracers + 1
+        end if
+
         actual_bgc_num = num_tracers - num_physical_tracers
         if (use_age_tracer) actual_bgc_num = actual_bgc_num - 1
+        if (use_transit) actual_bgc_num = actual_bgc_num - n_transit_tracers
+
+        bgc_start = num_physical_tracers + 1
+        bgc_end   = num_physical_tracers + actual_bgc_num
 
         ! ======================================================================================
         !********************************* LOOP STARTS *****************************************
@@ -343,9 +369,7 @@ contains
             rhoSW_watercolumn(1:nzmax) = rhoSW3D(1:nzmax, n)
 
             !!---- Biogeochemical tracers
-            !do tr_num = num_tracers - bgc_num + 1, num_tracers
-            do tr_num = num_physical_tracers+1, num_physical_tracers+actual_bgc_num
-               ! C(1:nzmax, tr_num - 2) = tracers_info%data_pointers(tr_num)%tracer_data(1:nzmax, n)
+            do tr_num = bgc_start, bgc_end
                 C(1:nzmax, tr_num-num_physical_tracers) = tracers_info%data_pointers(tr_num)%tracer_data(1:nzmax, n)
             end do
 
@@ -372,115 +396,6 @@ contains
                 ! Allocate and initialize all diagnostic arrays for a water column
                 call allocate_and_init_diags(nl)
             end if
-            !
-            !        !! * Allocate 3D diagnostics *
-            !            allocate(vertrespmeso(nl-1))
-            !            vertrespmeso  = 0.d0
-            !
-            !if (enable_3zoo2det) then
-            !            allocate(vertrespmacro(nl-1), vertrespmicro(nl-1))
-            !            vertrespmacro = 0.d0
-            !            vertrespmicro = 0.d0
-            !endif
-            !            allocate(vertcalcdiss(nl-1), vertcalcif(nl-1))
-            !            vertcalcdiss = 0.d0
-            !            vertcalcif   = 0.d0
-            !
-            !            allocate(vertaggn(nl-1), vertaggd(nl-1))
-            !            vertaggn = 0.d0
-            !            vertaggd = 0.d0
-            !
-            !            allocate(vertdocexn(nl-1), vertdocexd(nl-1))
-            !            vertdocexn = 0.d0
-            !            vertdocexd = 0.d0
-            !
-            !            allocate(vertrespn(nl-1), vertrespd(nl-1))
-            !            vertrespn = 0.d0
-            !            vertrespd = 0.d0
-            !
-            !            allocate(VTPhyCO2(nl-1), VTDiaCO2(nl-1))
-            !            VTPhyCO2 = 0.d0
-            !            VTDiaCO2 = 0.d0
-            !
-            !            allocate(VTCphotLigLim_phyto(nl-1), VTCphotLigLim_diatoms(nl-1))
-            !            VTCphotLigLim_phyto = 0.d0
-            !            VTCphotLigLim_diatoms = 0.d0
-            !
-            !            allocate(VTCphot_phyto(nl-1), VTCphot_diatoms(nl-1))
-            !            VTCphot_phyto = 0.d0
-            !            VTCphot_diatoms = 0.d0
-            !
-            !if (enable_coccos) then
-            !            allocate(VTTemp_diatoms(nl-1), VTTemp_phyto(nl-1))
-            !            VTTemp_diatoms = 0.d0
-            !            VTTemp_phyto = 0.d0
-            !
-            !            allocate(VTqlimitFac_phyto(nl-1), VTqlimitFac_diatoms(nl-1))
-            !            VTqlimitFac_phyto = 0.d0
-            !            VTqlimitFac_diatoms = 0.d0
-            !
-            !            allocate(VTSi_assimDia(nl-1))
-            !            VTSi_assimDia = 0.d0
-            !
-            !            allocate(vertaggc(nl-1), vertdocexc(nl-1), vertrespc(nl-1))
-            !            vertaggc = 0.d0
-            !            vertdocexc = 0.d0
-            !            vertrespc = 0.d0
-            !
-            !            allocate(vertaggp(nl-1), vertdocexp(nl-1), vertrespp(nl-1)) ! Phaeocystis
-            !            vertaggp = 0.d0
-            !            vertdocexp = 0.d0
-            !            vertrespp = 0.d0
-            !
-            !            allocate(VTTemp_cocco(nl-1), VTTemp_phaeo(nl-1))
-            !            VTTemp_cocco = 0.d0
-            !            VTTemp_phaeo = 0.d0
-            !
-            !            allocate(VTCoccoCO2(nl-1), VTPhaeoCO2(nl-1))
-            !            VTCoccoCO2 = 0.d0
-            !            VTPhaeoCO2 = 0.d0
-            !
-            !            allocate(VTqlimitFac_cocco(nl-1), VTqlimitFac_phaeo(nl-1))
-            !            VTqlimitFac_cocco  = 0.d0
-            !            VTqlimitFac_phaeo  = 0.d0
-            !
-            !            allocate(VTCphotLigLim_cocco(nl-1), VTCphotLigLim_phaeo(nl-1))
-            !            VTCphotLigLim_cocco  = 0.d0
-            !            VTCphotLigLim_phaeo  = 0.d0
-            !
-            !            allocate(VTCphot_cocco(nl-1), VTCphot_phaeo(nl-1))
-            !            VTCphot_cocco  = 0.d0
-            !            VTCphot_phaeo  = 0.d0
-            !
-            !
-            !endif
-            !
-            !            !! * Allocate 2D diagnostics *
-            !            allocate(vertNPPn(nl-1), vertGPPn(nl-1), vertNNAn(nl-1), vertChldegn(nl-1))
-            !            vertNPPn = 0.d0
-            !            vertGPPn = 0.d0
-            !            vertNNAn = 0.d0
-            !            vertChldegn  = 0.d0
-            !
-            !            allocate(vertNPPd(nl-1), vertGPPd(nl-1), vertNNAd(nl-1), vertChldegd(nl-1))
-            !            vertNPPd = 0.d0
-            !            vertGPPd = 0.d0
-            !            vertNNAd = 0.d0
-            !            vertChldegd  = 0.d0
-            !
-            !if (enable_coccos) then
-            !            allocate(vertNPPc(nl-1), vertGPPc(nl-1), vertNNAc(nl-1), vertChldegc(nl-1))
-            !            vertNPPc = 0.d0
-            !            vertGPPc = 0.d0
-            !            vertNNAc = 0.d0
-            !            vertChldegc = 0.d0
-            !
-            !            allocate(vertNPPp(nl-1), vertGPPp(nl-1), vertNNAp(nl-1), vertChldegp(nl-1))
-            !            vertNPPp = 0.d0
-            !            vertGPPp = 0.d0
-            !            vertNNAp = 0.d0
-            !            vertChldegp = 0.d0
-            !endif
 
             if (recom_debug .and. mype == 0) then
                 print *, achar(27) // '[36m' // '     -->' // &
@@ -496,16 +411,13 @@ contains
                     HCO3_watercolumn, & ! NEW MOCSY HCO3 for the whole watercolumn
                     CO3_watercolumn, & ! NEW DISS CO3 for the whole watercolumn
                     OmegaC_watercolumn, & ! NEW DISS OmegaC for the whole watercolumn
-            ! NEW DISS stoichiometric solubility product for calcite [mol^2/kg^2]
-                    kspc_watercolumn, &
+                    kspc_watercolumn, & ! NEW DISS stoichiometric solubility product for calcite [mol^2/kg^2]
                     rhoSW_watercolumn, & ! NEW DISS in-situ density of seawater [mol/m^3]
                     PAR, MPI_COMM_FESOM, mype, myDim_nod2D, &
                     eDim_nod2D, nl, hnode, zbar_3d_n, &
                     geo_coord_nod2D, daynew, ndpyr, dt, kappa, mstep, rad)
 
-            !do tr_num = num_tracers - bgc_num + 1, num_tracers !bgc_num+2
-            do tr_num = num_physical_tracers+1, num_physical_tracers+actual_bgc_num
-                !tracers_info%data_pointers(tr_num)%tracer_data(1:nzmax, n) = C(1:nzmax, tr_num - 2)
+            do tr_num = bgc_start, bgc_end
                 tracers_info%data_pointers(tr_num)%tracer_data(1:nzmax, n) = C(1:nzmax, tr_num-num_physical_tracers)
             end do
 
@@ -537,123 +449,6 @@ contains
                 ! Deallocate vertical tracer array
                 call deallocate_diags()
             end if
-            !            !! * Update 2D diagnostics *
-            !            NPPn(n) = locNPPn
-            !            NPPd(n) = locNPPd
-            !            GPPn(n) = locGPPn
-            !            GPPd(n) = locGPPd
-            !            NNAn(n) = locNNAn
-            !            NNAd(n) = locNNAd
-            !            Chldegn(n) = locChldegn
-            !            Chldegd(n) = locChldegd
-            !
-            !if (enable_coccos) then
-            !            NPPc(n) = locNPPc
-            !            GPPc(n) = locGPPc
-            !            NNAc(n) = locNNAc
-            !            Chldegc(n) = locChldegc
-            !            NPPp(n) = locNPPp
-            !            GPPp(n) = locGPPp
-            !            NNAp(n) = locNNAp
-            !            Chldegp(n) = locChldegp
-            !endif
-            !
-            !            !! * Update 3D diagnostics *
-            !            respmeso     (1:nzmax,n) = vertrespmeso     (1:nzmax)
-            !if (enable_3zoo2det) then
-            !            respmacro    (1:nzmax,n) = vertrespmacro    (1:nzmax)
-            !            respmicro    (1:nzmax,n) = vertrespmicro    (1:nzmax)
-            !endif
-            !            calcdiss     (1:nzmax,n) = vertcalcdiss     (1:nzmax)
-            !            calcif       (1:nzmax,n) = vertcalcif       (1:nzmax)
-            !
-            !            aggn         (1:nzmax,n) = vertaggn         (1:nzmax)
-            !            docexn       (1:nzmax,n) = vertdocexn       (1:nzmax)
-            !            respn        (1:nzmax,n) = vertrespn        (1:nzmax)
-            !            NPPn3D       (1:nzmax,n) = vertNPPn         (1:nzmax)
-            !
-            !            aggd         (1:nzmax,n) = vertaggd         (1:nzmax)
-            !            docexd       (1:nzmax,n) = vertdocexd       (1:nzmax)
-            !            respd        (1:nzmax,n) = vertrespd        (1:nzmax)
-            !            NPPd3D       (1:nzmax,n) = vertNPPd         (1:nzmax)
-            !
-            !            TPhyCO2             (1:nzmax,n) = VTPhyCO2                  (1:nzmax)
-            !            TDiaCO2             (1:nzmax,n) = VTDiaCO2                  (1:nzmax)
-            !            TCphotLigLim_phyto  (1:nzmax,n) = VTCphotLigLim_phyto       (1:nzmax)
-            !            TCphotLigLim_diatoms(1:nzmax,n) = VTCphotLigLim_diatoms     (1:nzmax)
-            !            TCphot_phyto        (1:nzmax,n) = VTCphot_phyto             (1:nzmax)
-            !            TCphot_diatoms      (1:nzmax,n) = VTCphot_diatoms           (1:nzmax)
-            !
-            !if (enable_coccos) then
-            !
-            !            TTemp_phyto         (1:nzmax,n) = VTTemp_phyto              (1:nzmax)
-            !            TqlimitFac_phyto    (1:nzmax,n) = VTqlimitFac_phyto         (1:nzmax)
-            !            TTemp_diatoms       (1:nzmax,n) = VTTemp_diatoms            (1:nzmax) !!
-            ! NEW from here tracking vars
-            !            TqlimitFac_diatoms  (1:nzmax,n) = VTqlimitFac_diatoms       (1:nzmax)
-            !            TSi_assimDia        (1:nzmax,n) = VTSi_assimDia             (1:nzmax)
-            !
-            !            aggc         (1:nzmax,n) = vertaggc         (1:nzmax)
-            !            docexc       (1:nzmax,n) = vertdocexc       (1:nzmax)
-            !            respc        (1:nzmax,n) = vertrespc        (1:nzmax)
-            !            NPPc3D       (1:nzmax,n) = vertNPPc         (1:nzmax)
-            !
-            !            aggp         (1:nzmax,n) = vertaggp         (1:nzmax)
-            !            docexp       (1:nzmax,n) = vertdocexp       (1:nzmax)
-            !            respp        (1:nzmax,n) = vertrespp        (1:nzmax)
-            !            NPPp3D       (1:nzmax,n) = vertNPPp         (1:nzmax)
-            !
-            !            TTemp_cocco         (1:nzmax,n) = VTTemp_cocco              (1:nzmax)
-            !            TCoccoCO2           (1:nzmax,n) = VTCoccoCO2                (1:nzmax)
-            !            TqlimitFac_cocco    (1:nzmax,n) = VTqlimitFac_cocco         (1:nzmax)
-            !            TCphotLigLim_cocco  (1:nzmax,n) = VTCphotLigLim_cocco       (1:nzmax)
-            !            TCphot_cocco        (1:nzmax,n) = VTCphot_cocco             (1:nzmax)
-            !
-            !            TTemp_phaeo         (1:nzmax,n) = VTTemp_phaeo              (1:nzmax)
-            !            TPhaeoCO2           (1:nzmax,n) = VTPhaeoCO2                (1:nzmax)
-            !            TqlimitFac_phaeo    (1:nzmax,n) = VTqlimitFac_phaeo         (1:nzmax)
-            !            TCphotLigLim_phaeo  (1:nzmax,n) = VTCphotLigLim_phaeo       (1:nzmax)
-            !            TCphot_phaeo        (1:nzmax,n) = VTCphot_phaeo             (1:nzmax)
-            !
-            !    endif
-            !
-            !if (recom_debug .and. mype==0) print *, achar(27)//'[36m'//'     --> ciso after
-            !REcoM_Forcing'//achar(27)//'[0m'
-            !
-            !            !! * Deallocating 2D diagnostics *
-            !            deallocate(vertNPPn, vertGPPn, vertNNAn, vertChldegn)
-            !            deallocate(vertNPPd, vertGPPd, vertNNAd, vertChldegd)
-            !if (enable_coccos) then
-            !            deallocate(vertNPPc, vertGPPc, vertNNAc, vertChldegc)
-            !            deallocate(vertNPPp, vertGPPp, vertNNAp, vertChldegp)
-            !endif
-            !
-            !            !! * Deallocating 3D Diagnostics *
-            !            deallocate(vertrespmeso)
-            !if (enable_3zoo2det) then
-            !            deallocate(vertrespmacro, vertrespmicro)
-            !endif
-            !            deallocate(vertcalcdiss, vertcalcif)
-            !            deallocate(vertaggn, vertdocexn, vertrespn)
-            !            deallocate(vertaggd, vertdocexd, vertrespd)
-            !            deallocate(VTPhyCO2, VTCphotLigLim_phyto, VTCphot_phyto)
-            !            deallocate(VTDiaCO2, VTCphotLigLim_diatoms, VTCphot_diatoms)
-            !
-            !if (enable_coccos) then
-            !           deallocate(vertgrazmeso_c)
-            !            deallocate(VTTemp_phyto, VTqlimitFac_phyto)
-            !            deallocate(VTTemp_diatoms, VTqlimitFac_diatoms)
-            !
-            !            deallocate(VTSi_assimDia)
-            !            deallocate(vertaggc, vertdocexc, vertrespc)
-            !            deallocate(vertaggp, vertdocexp, vertrespp)
-            !
-            !            deallocate(VTTemp_cocco, VTCoccoCO2, VTqlimitFac_cocco,
-            ! VTCphotLigLim_cocco, VTCphot_cocco)
-            !            deallocate(VTTemp_phaeo, VTPhaeoCO2, VTqlimitFac_phaeo,
-            ! VTCphotLigLim_phaeo, VTCphot_phaeo)
-            !
-            !endif
 
             AtmFeInput(n) = FeDust
             AtmNInput(n) = NDust

--- a/recom_modules.F90
+++ b/recom_modules.F90
@@ -405,11 +405,9 @@ module REcoM_declarations
     type(recom_tracer_ids) :: tracer_ids
 
 end module REcoM_declarations
-
 !
 !===============================================================================
 !
-
 module recom_config
     use recom_declarations, only: wp
     implicit none
@@ -1072,23 +1070,31 @@ contains
     ! ==============================================================================
     ! Purpose: Validate consistency between namelist tracer configuration and
     !          biogeochemical model setup (enable_3zoo2det, enable_coccos)
+    !
+    ! Tracer layout (fixed order):
+    !   T, S  |  BGC (bgc_num tracers)  |  age (optional, ID=100)  |  transit (optional)
+    !
+    ! BGC tracers always start immediately at slot 3 (right after T, S),
+    ! regardless of whether transit tracers are active. Transit tracers
+    ! (SF6, CFC-11, CFC-12, R14C, R39Ar) are appended at the very end,
+    ! after the optional age tracer.
     ! ==============================================================================
-    subroutine validate_recom_tracers(num_tracers, use_age_tracer, mype)
+    subroutine validate_recom_tracers(num_tracers, use_age_tracer, use_transit, l_sf6, l_f11, l_f12, l_r14c, l_r39ar, mype)
         use mpi, only: MPI_Abort, MPI_COMM_WORLD
-        !use g_forcing_param,  only: use_age_tracer
 
         implicit none
 
         ! Arguments
         integer, intent(in) :: num_tracers ! Total number of tracers from namelist
-        logical, intent(in) :: use_age_tracer
+        logical, intent(in) :: use_age_tracer, use_transit, l_sf6, l_f11, l_f12, l_r14c, l_r39ar
         integer, intent(in) :: mype ! MPI rank
 
         ! Local variables
         integer :: expected_bgc_num
         integer :: actual_bgc_num
         integer :: expected_total_tracers
-        integer :: num_physical_tracers
+        integer :: bgc_offset              ! offset of last base-BGC slot (T,S + 22)
+        integer :: n_transit_tracers       ! number of active transit tracers
         integer :: MPIErr
         logical :: config_error
 
@@ -1100,13 +1106,25 @@ contains
         logical :: id_error
         integer :: slot                   ! running slot index when building expected_ids
 
-        ! Physical tracers (temperature, salinity, etc.) - typically first 2
-        num_physical_tracers = 2
+        logical :: num_physical_tracers
+        integer, parameter :: n_base_physical = 2   ! T (id=1), S (id=2)
+
+        ! ---- count active transit tracers -----------------------------------------
+        n_transit_tracers = 0
+        if (use_transit) then
+            if (l_sf6)   n_transit_tracers = n_transit_tracers + 1
+            if (l_f11)   n_transit_tracers = n_transit_tracers + 1
+            if (l_f12)   n_transit_tracers = n_transit_tracers + 1
+            if (l_r14c)  n_transit_tracers = n_transit_tracers + 1
+            if (l_r39ar) n_transit_tracers = n_transit_tracers + 1
+        end if
 
         ! ---- actual BGC count: strip non-BGC appended tracers --------------------
-        ! tracer_init appends in this order:  BGC | [age]
-        actual_bgc_num = num_tracers - num_physical_tracers
+        ! tracer_init now appends in this order:  T,S | BGC | [age] | [transit]
+        ! num_physical_tracers here is just T,S (=2) in the reordered layout.
+        actual_bgc_num = num_tracers - n_base_physical
         if (use_age_tracer) actual_bgc_num = actual_bgc_num - 1
+        actual_bgc_num = actual_bgc_num - n_transit_tracers
 
         ! ===========================================================================
         ! Determine expected BGC tracer count based on configuration
@@ -1155,9 +1173,12 @@ contains
 
         end if
 
-        !   T, S  +  BGC  +  age (opt)
-        expected_total_tracers = num_physical_tracers + expected_bgc_num
+        !   T, S  +  BGC  +  age (opt)  +  transit (opt)
+        expected_total_tracers = n_base_physical + expected_bgc_num
         if (use_age_tracer) expected_total_tracers = expected_total_tracers + 1
+        expected_total_tracers = expected_total_tracers + n_transit_tracers
+
+        num_physical_tracers = n_base_physical
 
         ! ===========================================================================
         ! Build expected tracer ID list for current configuration
@@ -1169,65 +1190,90 @@ contains
         allocate(tracer_found(num_expected_tracers))
         tracer_found = .false.
 
-        ! Physical tracers (always present)
+        ! Physical tracers (always present, always first)
         expected_tracer_ids(1) = 1 ! Temperature
         expected_tracer_ids(2) = 2 ! Salinity
 
-        ! Base BGC tracers (always present for all configurations)
+        ! Base BGC tracers (always present for all configurations) - start right after T,S
         do i = 1, 22
-            expected_tracer_ids(num_physical_tracers + i) = 1000 + i
+            expected_tracer_ids(n_base_physical + i) = 1000 + i
         end do
 
         ! Configuration-specific tracers
+        ! bgc_offset = last slot of the base BGC block; BGC always starts at slot 3
+        bgc_offset = n_base_physical + 22
+
         if (enable_3zoo2det .and. enable_coccos) then
-            ! Full model: 1001-1022 (base) + 1023-1024 (zoo2) + 1025-1028 (det2) + 1029-1036
+            ! Full model: base + 1023-1024 (zoo2) + 1025-1028 (det2) + 1029-1036
             ! (coccos+phaeo+zoo3)
-            expected_tracer_ids(25) = 1023 ! Zoo2N
-            expected_tracer_ids(26) = 1024 ! Zoo2C
-            expected_tracer_ids(27) = 1025 ! DetZ2N
-            expected_tracer_ids(28) = 1026 ! DetZ2C
-            expected_tracer_ids(29) = 1027 ! DetZ2Si
-            expected_tracer_ids(30) = 1028 ! DetZ2Calc
-            expected_tracer_ids(31) = 1029 ! CoccoN
-            expected_tracer_ids(32) = 1030 ! CoccoC
-            expected_tracer_ids(33) = 1031 ! CoccoChl
-            expected_tracer_ids(34) = 1032 ! PhaeoN
-            expected_tracer_ids(35) = 1033 ! PhaeoC
-            expected_tracer_ids(36) = 1034 ! PhaeoChl
-            expected_tracer_ids(37) = 1035 ! Zoo3N
-            expected_tracer_ids(38) = 1036 ! Zoo3C
+            expected_tracer_ids(bgc_offset + 1)  = 1023 ! Zoo2N
+            expected_tracer_ids(bgc_offset + 2)  = 1024 ! Zoo2C
+            expected_tracer_ids(bgc_offset + 3)  = 1025 ! DetZ2N
+            expected_tracer_ids(bgc_offset + 4)  = 1026 ! DetZ2C
+            expected_tracer_ids(bgc_offset + 5)  = 1027 ! DetZ2Si
+            expected_tracer_ids(bgc_offset + 6)  = 1028 ! DetZ2Calc
+            expected_tracer_ids(bgc_offset + 7)  = 1029 ! CoccoN
+            expected_tracer_ids(bgc_offset + 8)  = 1030 ! CoccoC
+            expected_tracer_ids(bgc_offset + 9)  = 1031 ! CoccoChl
+            expected_tracer_ids(bgc_offset + 10) = 1032 ! PhaeoN
+            expected_tracer_ids(bgc_offset + 11) = 1033 ! PhaeoC
+            expected_tracer_ids(bgc_offset + 12) = 1034 ! PhaeoChl
+            expected_tracer_ids(bgc_offset + 13) = 1035 ! Zoo3N
+            expected_tracer_ids(bgc_offset + 14) = 1036 ! Zoo3C
 
         else if (enable_coccos .and. .not.enable_3zoo2det) then
-            ! Coccos only: 1001-1022 (base) + 1023-1028 (coccos+phaeo)
-            expected_tracer_ids(25) = 1023 ! CoccoN
-            expected_tracer_ids(26) = 1024 ! CoccoC
-            expected_tracer_ids(27) = 1025 ! CoccoChl
-            expected_tracer_ids(28) = 1026 ! PhaeoN
-            expected_tracer_ids(29) = 1027 ! PhaeoC
-            expected_tracer_ids(30) = 1028 ! PhaeoChl
+            ! Coccos only: base + 1023-1028 (coccos+phaeo)
+            expected_tracer_ids(bgc_offset + 1) = 1023 ! CoccoN
+            expected_tracer_ids(bgc_offset + 2) = 1024 ! CoccoC
+            expected_tracer_ids(bgc_offset + 3) = 1025 ! CoccoChl
+            expected_tracer_ids(bgc_offset + 4) = 1026 ! PhaeoN
+            expected_tracer_ids(bgc_offset + 5) = 1027 ! PhaeoC
+            expected_tracer_ids(bgc_offset + 6) = 1028 ! PhaeoChl
 
         else if (enable_3zoo2det .and. .not.enable_coccos) then
-            ! 3Zoo2Det only: 1001-1022 (base) + 1023-1030 (zoo2+det2+zoo3)
-            expected_tracer_ids(25) = 1023 ! Zoo2N
-            expected_tracer_ids(26) = 1024 ! Zoo2C
-            expected_tracer_ids(27) = 1025 ! DetZ2N
-            expected_tracer_ids(28) = 1026 ! DetZ2C
-            expected_tracer_ids(29) = 1027 ! DetZ2Si
-            expected_tracer_ids(30) = 1028 ! DetZ2Calc
-            expected_tracer_ids(31) = 1029 ! Zoo3N
-            expected_tracer_ids(32) = 1030 ! Zoo3C
+            ! 3Zoo2Det only: base + 1023-1030 (zoo2+det2+zoo3)
+            expected_tracer_ids(bgc_offset + 1) = 1023 ! Zoo2N
+            expected_tracer_ids(bgc_offset + 2) = 1024 ! Zoo2C
+            expected_tracer_ids(bgc_offset + 3) = 1025 ! DetZ2N
+            expected_tracer_ids(bgc_offset + 4) = 1026 ! DetZ2C
+            expected_tracer_ids(bgc_offset + 5) = 1027 ! DetZ2Si
+            expected_tracer_ids(bgc_offset + 6) = 1028 ! DetZ2Calc
+            expected_tracer_ids(bgc_offset + 7) = 1029 ! Zoo3N
+            expected_tracer_ids(bgc_offset + 8) = 1030 ! Zoo3C
         end if
 
-
-       ! Age tracer (ID=100): appended immediately after the last BGC slot.
-       ! slot = 2 (T,S) + expected_bgc_num + 1
-       slot = num_physical_tracers + expected_bgc_num + 1
-       if (use_age_tracer) then
-           expected_tracer_ids(slot) = 100
-           slot = slot + 1
-       end if
-
         ! else: base configuration only needs tracers 1, 2, 1001-1022
+
+        ! ---- Age tracer (ID=100): appended immediately after the last BGC slot -----
+        slot = n_base_physical + expected_bgc_num + 1
+        if (use_age_tracer) then
+            expected_tracer_ids(slot) = 100
+            slot = slot + 1
+        end if
+
+        ! ---- Transit tracers: appended at the very end, after age ------------------
+        if (use_transit) then
+            if (l_sf6) then
+                expected_tracer_ids(slot) = 6 ! SF6
+                slot = slot + 1
+            end if
+            if (l_f11) then
+                expected_tracer_ids(slot) = 11 ! CFC-11
+                slot = slot + 1
+            end if
+            if (l_f12) then
+                expected_tracer_ids(slot) = 12! CFC-12
+                slot = slot + 1
+            end if
+            if (l_r14c) then
+                expected_tracer_ids(slot) = 14 ! R14C (radiocarbon)
+                slot = slot + 1
+            end if
+            if (l_r39ar) then
+                expected_tracer_ids(slot) = 39 ! R39Ar
+                slot = slot + 1
+            end if
+        end if
 
         ! ===========================================================================
         ! Perform validation checks
@@ -1246,10 +1292,14 @@ contains
             write(*, *) '  enable_3zoo2det = ', enable_3zoo2det
             write(*, *) '  enable_coccos   = ', enable_coccos
             write(*,*)  '  use_age_tracer  = ', use_age_tracer
+            write(*,*)  '  use_transit     = ', use_transit
+            write(*, *) ''
+            write(*, *) 'Tracer layout: T, S | BGC | [age] | [transit]'
             write(*, *) ''
             write(*, *) 'Tracer counts:'
-            write(*, *) '  Physical tracers (T, S, ...)      = ', num_physical_tracers
+            write(*, *) '  Physical tracers (T, S)           = ', n_base_physical
             write(*,*) '  Age tracer  (ID=100)               = ', merge(1, 0, use_age_tracer)
+            write(*,*) '  Transit tracers                    = ', n_transit_tracers
             write(*, *) '  Expected BGC tracers              = ', expected_bgc_num
             write(*, *) '  Expected TOTAL tracers            = ', expected_total_tracers
             write(*, *) '  Actual tracers from namelist      = ', num_tracers
@@ -1299,6 +1349,7 @@ contains
                 write(*, *) '  1. Check your namelist.config tracer_list section'
                 write(*, *) '  2. Ensure enable_3zoo2det and enable_coccos match your setup'
                 write(*, *) '  3. Add/remove tracers to match the expected configuration'
+                write(*, *) '  4. Ensure order is T, S | BGC | [age] | [transit]'
                 write(*, *) '======================================================================&
                         &===='
                 write(*, *) ''
@@ -1353,16 +1404,28 @@ contains
             write(*, *) ''
 
             ! Display expected IDs in a readable format
-            write(*, *) 'Physical tracers:'
-            write(*, *) '  ', expected_tracer_ids(1:num_physical_tracers)
+            write(*, *) 'Physical tracers (T, S):'
+            write(*, *) '  ', expected_tracer_ids(1:n_base_physical)
             write(*, *) ''
             write(*, *) 'Base BGC tracers (1001-1022):'
-            write(*, *) '  ', expected_tracer_ids(3:24)
+            write(*, *) '  ', expected_tracer_ids(n_base_physical+1:n_base_physical+22)
             write(*, *) ''
 
             if (expected_bgc_num > 22) then
                 write(*, *) 'Extended configuration tracers:'
-                write(*, *) '  ', expected_tracer_ids(25:num_expected_tracers)
+                write(*, *) '  ', expected_tracer_ids(n_base_physical+23:n_base_physical+expected_bgc_num)
+                write(*, *) ''
+            end if
+
+            if (use_age_tracer) then
+                write(*, *) 'Age tracer:'
+                write(*, *) '  ', expected_tracer_ids(n_base_physical+expected_bgc_num+1)
+                write(*, *) ''
+            end if
+
+            if (use_transit .and. n_transit_tracers > 0) then
+                write(*, *) 'Transit tracers (tail):'
+                write(*, *) '  ', expected_tracer_ids(num_expected_tracers-n_transit_tracers+1:num_expected_tracers)
                 write(*, *) ''
             end if
 
@@ -1374,12 +1437,12 @@ contains
             write(*, *) '  - Tracer ID clashes between configurations'
             write(*, *) '  - Incorrect order of tracer IDs in namelist'
             write(*, *) '  - Missing or duplicate tracer IDs'
+            write(*, *) '  - Placing transit tracers before BGC tracers (they now go at the end)'
             write(*, *) ''
 
             ! Configuration-specific warnings
             if (enable_3zoo2det .and. enable_coccos) then
                 write(*, *) 'IMPORTANT for FULL MODEL (3zoo2det + coccos):'
-                !  write(*,*) '  - Tracers 1023-1024 are NOT used (reserved for other configs)'
                 write(*, *) '  - Zoo2 uses:         1023-1024'
                 write(*, *) '  - Det2 pool uses:    1025-1028'
                 write(*, *) '  - Coccos uses:       1029-1031'
@@ -1421,8 +1484,6 @@ contains
             ! Warn about potential clashes between configurations
             if (enable_3zoo2det .and. enable_coccos) then
                 write(*, *) 'Full model configuration active.'
-                !  write(*,*) 'Ensure you are NOT using tracer IDs 1023-1024 in your namelist!'
-                !  write(*,*) 'These are reserved for configurations WITHOUT full model.'
             else if (enable_coccos) then
                 write(*, *) 'Coccos-only configuration active.'
                 write(*, *) 'Coccos MUST use IDs 1023-1025 (NOT 1029-1031).'
@@ -1433,7 +1494,6 @@ contains
             end if
 
             write(*, *) ''
-            ! write(*,*) 'No automated clash detection available without tracer array access.'
             write(*, *) 'Please manually verify your namelist tracer_list against the'
             write(*, *) 'expected sequence shown above.'
             write(*, *) '=========================================================================='
@@ -1468,20 +1528,19 @@ contains
     ! ==============================================================================
     ! Purpose: Validate that actual tracer IDs from namelist match expected sequence
     !          Call this after reading the tracer namelist
-    ! Builds the expected ID array using a running slot index for the tail
-    ! (age), exactly mirroring the append order in tracer_init:
-    !   slot  2+bgc_num+1  : age tracer ID=100            (only if use_age_tracer)
+    ! Builds the expected ID array as: T, S | BGC | [age] | [transit]
+    ! mirroring the append order in tracer_init.
     ! ==============================================================================
-    subroutine validate_tracer_id_sequence(tracer_ids, num_tracers, use_age_tracer, mype)
+    subroutine validate_tracer_id_sequence(tracer_ids, num_tracers, use_age_tracer, use_transit, &
+                                            l_sf6, l_f11, l_f12, l_r14c, l_r39ar, mype)
         use mpi, only: MPI_Abort, MPI_COMM_WORLD
-        !use g_forcing_param, only: use_age_tracer
 
         implicit none
 
         ! Arguments
         integer, dimension(:), intent(in) :: tracer_ids ! Actual IDs from namelist
         integer, intent(in) :: num_tracers ! Number of tracers
-        logical, intent(in) :: use_age_tracer
+        logical, intent(in) :: use_age_tracer, use_transit, l_sf6, l_f11, l_f12, l_r14c, l_r39ar
         integer, intent(in) :: mype ! MPI rank
 
         ! Local variables
@@ -1490,13 +1549,14 @@ contains
         integer :: MPIErr
         logical :: error_found
         logical :: duplicate_found
-        integer :: num_physical_tracers
         integer :: bgc_num_local           ! local BGC count derived from config flags
         integer :: slot                    ! running slot for age + transit tail
+        integer :: n_transit_tracers       ! number of active transit tracers
+        integer, parameter :: n_base_physical = 2   ! T (id=1), S (id=2)
+        logical :: num_physical_tracers
 
         error_found = .false.
         duplicate_found = .false.
-        num_physical_tracers = 2
 
         ! ---- derive local BGC count (same logic as validate_recom_tracers) --------
         if (enable_3zoo2det .and. enable_coccos) then
@@ -1509,6 +1569,9 @@ contains
             bgc_num_local = 22
         end if
 
+        ! num_physical_tracers (global) is just T,S in the new layout
+        num_physical_tracers = n_base_physical
+
         ! Allocate expected IDs array
         allocate(expected_ids(num_tracers))
         expected_ids = 0   ! zero-init; any unset slot is caught by the mismatch check
@@ -1517,36 +1580,64 @@ contains
         expected_ids(1) = 1
         expected_ids(2) = 2
 
-        ! ---- base BGC (slots 3-24, IDs 1001-1022, always present) ----------------
+        ! ---- base BGC (IDs 1001-1022, always present, starts right after T,S) ----
         do i = 1, 22
-            expected_ids(num_physical_tracers + i) = 1000 + i
+            expected_ids(n_base_physical + i) = 1000 + i
         end do
 
-        ! ---- config-specific BGC (slots 25 onwards) ------------------------------
+        ! ---- config-specific BGC (slots after base BGC block) ---------------------
         if (enable_3zoo2det .and. enable_coccos) then
             ! Full model configuration
-            expected_ids(25:30) = [1023, 1024, 1025, 1026, 1027, 1028]
-            expected_ids(31:36) = [1029, 1030, 1031, 1032, 1033, 1034]
-            expected_ids(37:38) = [1035, 1036]
+            expected_ids(n_base_physical+23:n_base_physical+28) = [1023, 1024, 1025, 1026, 1027, 1028]
+            expected_ids(n_base_physical+29:n_base_physical+34) = [1029, 1030, 1031, 1032, 1033, 1034]
+            expected_ids(n_base_physical+35:n_base_physical+36) = [1035, 1036]
 
         else if (enable_coccos .and. .not.enable_3zoo2det) then
-            expected_ids(25:30) = [1023, 1024, 1025, 1026, 1027, 1028]
+            expected_ids(n_base_physical+23:n_base_physical+28) = [1023, 1024, 1025, 1026, 1027, 1028]
 
         else if (enable_3zoo2det .and. .not.enable_coccos) then
-            expected_ids(25:32) = [1023, 1024, 1025, 1026, 1027, 1028, 1029, 1030]
+            expected_ids(n_base_physical+23:n_base_physical+30) = [1023, 1024, 1025, 1026, 1027, 1028, 1029, 1030]
         end if
 
-        ! ---- age tracer (running slot) ----------------------
-        ! slot advances from the first position after the last BGC tracer.
-        slot = num_physical_tracers + bgc_num_local + 1
+        ! ---- age tracer (running slot, right after BGC) ----------------------------
+        slot = n_base_physical + bgc_num_local + 1
 
-        ! Age tracer (ID=100): appended first, immediately after the last BGC slot.
+        ! Age tracer (ID=100): appended immediately after the last BGC slot.
         ! NOT a BGC tracer; not counted in bgc_num.
         if (use_age_tracer) then
             expected_ids(slot) = 100
             slot = slot + 1
         end if
 
+        ! ---- transit tracers (tail, after age) --------------------------------------
+        n_transit_tracers = 0
+        if (use_transit) then
+            if (l_sf6) then
+                expected_ids(slot) = 6 ! SF6
+                slot = slot + 1
+                n_transit_tracers = n_transit_tracers + 1
+            end if
+            if (l_f11) then
+                expected_ids(slot) = 11 ! CFC-11
+                slot = slot + 1
+                n_transit_tracers = n_transit_tracers + 1
+            end if
+            if (l_f12) then
+                expected_ids(slot) = 12 ! CFC-12
+                slot = slot + 1
+                n_transit_tracers = n_transit_tracers + 1
+            end if
+            if (l_r14c) then
+                expected_ids(slot) = 14 ! R14C (radiocarbon)
+                slot = slot + 1
+                n_transit_tracers = n_transit_tracers + 1
+            end if
+            if (l_r39ar) then
+                expected_ids(slot) = 39 ! R39Ar
+                slot = slot + 1
+                n_transit_tracers = n_transit_tracers + 1
+            end if
+        end if
 
         ! ===========================================================================
         ! Check 1: Compare actual vs expected tracer IDs
@@ -1556,6 +1647,7 @@ contains
             write(*, *) '=========================================================================='
             write(*, *) 'VALIDATING TRACER ID SEQUENCE FROM NAMELIST'
             write(*, *) '=========================================================================='
+            write(*, *) 'Expected layout: T, S | BGC | [age] | [transit]'
         end if
 
         do i = 1, num_tracers
@@ -1567,8 +1659,10 @@ contains
                     write(*, *) '  Found tracer ID:    ', tracer_ids(i)
                     ! position-specific hints
                     if (use_age_tracer .and. &
-                        i == num_physical_tracers + bgc_num_local + 1) &
+                        i == n_base_physical + bgc_num_local + 1) &
                         write(*,*) '  HINT: this slot must be age tracer ID=100'
+                    if (use_transit .and. i > n_base_physical + bgc_num_local + merge(1,0,use_age_tracer)) &
+                        write(*,*) '  HINT: this slot is in the transit-tracer tail block'
                     write(*, *) ''
                 end if
             end if
@@ -1592,24 +1686,6 @@ contains
         end do
 
         ! ===========================================================================
-        ! Check 3: Detect forbidden tracer IDs for current configuration
-        ! ===========================================================================
-        !if (enable_3zoo2det .and. enable_coccos) then
-        ! Check for forbidden IDs 1023-1024 in full model
-        !do i = 1, num_tracers
-        !if (tracer_ids(i) == 1023 .or. tracer_ids(i) == 1024) then
-        !error_found = .true.
-        !if (mype == 0) then
-        !write(*,*) 'ERROR: Forbidden tracer ID in full model configuration!'
-        !write(*,*) '  Tracer ID ', tracer_ids(i), ' at position ', i
-        !write(*,*) '  IDs 1023-1024 are NOT used when both flags are enabled'
-        !write(*,*) ''
-        !end if
-        !end if
-        !end do
-        !end if
-
-        ! ===========================================================================
         ! Report results
         ! ===========================================================================
         if (error_found .or. duplicate_found) then
@@ -1626,8 +1702,11 @@ contains
                 write(*, *) 'Actual tracer ID sequence from namelist:'
                 write(*, *) tracer_ids
                 write(*, *) ''
+                write(*, *) '  1. Layout must be: T, S | BGC | [age] | [transit]'
                 if (use_age_tracer) &
-                    write(*,*) '  2. Age tracer          ID=100  (use_age_tracer = .true.)'
+                    write(*,*) '  2. Age tracer          ID=100  (use_age_tracer = .true.), placed right after BGC'
+                if (use_transit) &
+                    write(*,*) '  3. Transit tracers placed at the END, after age (if any)'
                 write(*, *) 'ACTION REQUIRED:'
                 write(*, *) '  Correct the tracer IDs in your namelist.config file'
                 write(*, *) '  Ensure the sequence matches exactly as expected'
@@ -1652,7 +1731,9 @@ contains
                 write(*, *) 'All tracer IDs match expected sequence - no clashes detected.'
                 if (use_age_tracer) &
                     write(*,*) '  Age tracer   (ID=100) correctly placed at slot ', &
-                    num_physical_tracers + bgc_num_local + 1
+                    n_base_physical + bgc_num_local + 1
+                if (use_transit) &
+                    write(*,*) '  Transit tracers (', n_transit_tracers, ') correctly placed at tail'
                 write(*, *) '======================================================================&
                         &===='
                 write(*, *) ''
@@ -1933,7 +2014,6 @@ module REcoM_GloVar
     end type tracers_info_type
 
 end module REcoM_GloVar
-
 !===============================================================================
 ! For variables saved locally for each column and then used in REcoM
 !-------------------------------------------------------------------------------


### PR DESCRIPTION
Tracer layout is T,S | BGC | [age] | [transit], with transient tracers (SF6, CFC-11, CFC-12, R14C, R39Ar) appended after age. The BGC init/exchange loops in recom_interface assumed BGC tracers were the last bgc_num slots, which breaks once age and/or transient tracers are appended.

- Add use_transit, l_sf6, l_f11, l_f12, l_r14c, l_r39ar params to recom()
- Compute bgc_start/bgc_end from num_physical_tracers, age, and active transient tracer count instead of assuming BGC is the tail block
- Apply corrected bounds to the per-node C(:) read/write loops and the MPI exchange loop, so transient tracers are no longer misread as BGC